### PR TITLE
Update dockerfile to Alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.10
 
 RUN apk add --no-cache curl
 


### PR DESCRIPTION
Updated docker file to Alpine 3.10. Results in Curl version 7.66.0-r0 instead of 7.61.1-r2